### PR TITLE
New docs and 100% of coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,8 @@ So, whether is code or not you can help me out making this code more accessible 
 # Versioning
 I would love to say that [SemVer](https://semver.org/) or anything like that is used but, in my personal experience, this kind of approach doesn't work very well with me, the guy who could be committing in this project for two weeks in a roll and leave it for almost one year with no simple ```npm update```. So, no versioning system is used. 
 # TODO
-Since I will be keeping this README up to date with any major change and I don't use any versioning system to log all the fixed bugs or previous projects updates, you can still have a taste of what comes next right here:
+Since I will be keeping this README up to date with any major change and I don't use any versioning system to log all the fixed bugs or previous projects updates, you can still have a taste of what comes next and what is being under analysis right in the [Projects](https://github.com/Fazendaaa/podsearch_bot/projects/) tab.
 
-* Writing a notification system, so that upon a new episode release the user will be notified -- making it available this notification at user timezone;
-* Adding podcasts recommendations thanks to [_lowhigh_](https://www.reddit.com/r/TelegramBots/comments/875tsz/podsearchbot/dwao2qj/) feedback on Reddit;
-* Integration with [wit.ia](https://wit.ai/);
-* Change URL shortener since Goo.gl will be shut down;
-* Add statistics about the podcasts -- like a trending.
-## Maybe
-* Adding REDIS integration;
-* Spotify and Soundclound account integration -- if possible to integrate and add new podcasts to your player already of podcasts;
-* Create a GraphQL as a "cache" to requests -- use Promise racing to perform it better;
-* Improve recommendation system through "listening" the podcast content -- like this [post](https://medium.com/behavioral-signals-ai/using-ai-to-understand-the-way-a-movie-looks-and-sounds-fe931d487171) says about movies.
 # Authors
 * Only [me](https://github.com/Fazendaaa) for now.
 

--- a/__mocks__/nerdcast/unsupported/output/lastEpisode.2.json
+++ b/__mocks__/nerdcast/unsupported/output/lastEpisode.2.json
@@ -1,16 +1,19 @@
 {
+    "name": "Episode 6 – Comic Con Review, Cpt. Hydra? und die 1%",
+    "latest": "11th July 2016, 4:05 am",
     "keyboard": {
         "parse_mode": "Markdown",
         "reply_markup": {
             "inline_keyboard": [
                 [
                     {
+                        "text": "Subscribe",
                         "callback_data": "subscribe/1103141552",
                         "hide": false
                     },
                     {
-                        "callback_data": "episode/notAvailable/1103141552",
-                        "hide": false
+                        "text": "Listen now",
+                        "url": "https://goo.gl/yTNnvc"
                     }
                 ]
             ]

--- a/__tests__/others/stream.test.ts
+++ b/__tests__/others/stream.test.ts
@@ -42,10 +42,31 @@ class MockParser extends Parser {
     }
 }
 
+/**
+ * This  class will be used to test a podcast with a new pattern of episode link. This mock is without any knew pattern
+ * to simulate this.
+ */
+class MockParserLink extends Parser {
+    constructor(options?: object) {
+        super();
+    }
+
+    public parseURL(link: string): Promise<object> {
+        return new Promise((resolve, reject) => {
+            resolve({
+                items: [{
+                    title: 'test'
+                }]
+            });
+        });
+    }
+}
+
 const mockLanguage: string = 'en';
 const mockLanCode: string = 'en-us';
 const fetcherRss = new Parser();
 const mockFetcherRss = new MockParser();
+const mockFetcherLinkRss = new MockParserLink();
 
 const mockShorten = (link: string): Promise<string> =>
 new Promise((resolve: (data: string) => void, reject: (error: string) => void) => {
@@ -258,6 +279,20 @@ describe('Testing lastEpisode function.', () => {
         });
     });
 
+    test('Wrong episode link.', () => {
+        expect.assertions(1);
+
+        return readAsync('nerdcast/unsupported/input/searchCommand.json').then((mockInput: response) => {
+            return readAsync('nerdcast/unsupported/output/lastEpisode.1.json').then((mockOutput: resultExtended) => {
+                return expect(lastEpisode(mockInput.results[0].trackId, mockLanCode, mockI18nNode.api, shorten, mockFetcherLinkRss)).resolves.toEqual(mockOutput);
+            }).catch((error: Error) => {
+                throw (error);
+            });
+        }).catch((error: Error) => {
+            console.error(error);
+        });
+    });
+
     /**
      * Last at the time of this writing.
      */
@@ -265,7 +300,7 @@ describe('Testing lastEpisode function.', () => {
         expect.assertions(1);
 
         return readAsync('nerdcast/unsupported/input/searchCommand.json').then((mockInput: response) => {
-            return readAsync('nerdcast/unsupported/output/lastEpisode.1.json').then((mockOutput: resultExtended) => {
+            return readAsync('nerdcast/unsupported/output/lastEpisode.2.json').then((mockOutput: resultExtended) => {
                 return expect(lastEpisode(mockInput.results[0].trackId, mockLanCode, i18nNode.api, shorten, fetcherRss)).resolves.toEqual(mockOutput);
             }).catch((error: Error) => {
                 throw(error);

--- a/docs/readme/README_PT.md
+++ b/docs/readme/README_PT.md
@@ -113,18 +113,7 @@ Caso seja o código ou não, você pode me ajudar lendo as diretrizes no arquivo
 # Controle de versão
 Eu adoraria dizer que [SemVer](https://semver.org/) ou algo do tipo fora utilizado porém, em experiência pessoal, esse tipo de aborgaem não funciona muito bem comigo, o cara que pode comitar várias vezes esse projeto por duas semanas seguidas e passar um anos sem dar um simples ```npm update``` no projeto. Então, não se é utilizado sistemas de versionamento.
 # A realizar
-Como esse README estará sendo atualizado com as mudanças importantes, não pretendo utilizar nenhum histórico de atualizações de bugs corrigidos ou novas funcionalidades. Todavia, você pode ter uma noção do que virá:
-
-* Escrever um sistema de notificação para que usuário saiba quando saiu um novo episódio do podcast que ele ouve -- e fazer de tal maneira que leve em consideração a posição no globo que ele se encontra;
-* Adicionar recomendações de podcasts baseado no que ouve, ideia do [_lowhigh_](https://www.reddit.com/r/TelegramBots/comments/875tsz/podsearchbot/dwao2qj/) no feedback que me deu no Reddit;
-* Integração com o [wit.ia](https://wit.ai/);
-* Mudar o encurtardor de URL já que o Goo.gl será desativado;
-* Adicionar estatísticas sobre os podcasts -- como um ranking.
-## Em análise
-* Adicionar integração com o REDIS;
-* Integração com Spotify e Soundclound -- se for possível, facilitar acesso a podcasts através dos programas que boa parte das pessoas já utilizam;
-* Criar um GraphQL como uma "cache" para as requisições -- usar racing Promises para rodar melhor;
-* Fazer com que o sistema de recomendações melhore após "ouvir" as podcasts -- assim como essa [reportagem](https://medium.com/behavioral-signals-ai/using-ai-to-understand-the-way-a-movie-looks-and-sounds-fe931d487171) diz sobre filmes.
+Como esse README estará sendo atualizado com as mudanças importantes, não pretendo utilizar nenhum histórico de atualizações de bugs corrigidos ou novas funcionalidades. Todavia, você pode ter uma noção do que virá e o que está sob análise na aba de [Projects](https://github.com/Fazendaaa/podsearch_bot/projects/) -- aviso: o conteúdo se encontra em Inglês.
 # Autores
 * Apenas [eu](https://github.com/Fazendaaa) até agora.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,15 +54,6 @@
       "integrity": "sha512-Dt7aifQmvMPTLVimzvfQ99qUn4zeSDCQarFNV4otfDLYu0RFdSRBnqSLgksoAnsRL88xJ/UBKbd66iP2XIab0w==",
       "dev": true
     },
-    "@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
-      "dev": true,
-      "requires": {
-        "moment": "2.21.0"
-      }
-    },
     "@types/mongodb": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@types/dotenv": "^4.0.2",
     "@types/jest": "^22.2.2",
-    "@types/moment": "^2.13.0",
     "@types/mongoose": "^5.0.9",
     "@types/node": "^9.6.0",
     "app.json": "^1.3.0",


### PR DESCRIPTION
Moving TODO in README to project tab in Github, as Kanban method is easy to see the big picture and keeping the project up to date without any need to update each time the README.

Improving system test coverage to 100% also.